### PR TITLE
[npwg] Prototype for default network

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,23 @@ Given the following network configuration:
 EOF
 
 ```
+
+### Further options for CNI configuration file.
+
+One may also specify `always_use_default` as a boolean value. This option requires that you're using the CRD method (and therefore requires that you must also specify both the `kubeconfig` and the `delegates` option as well, or Multus will present an error message). In the case that `always_use_default` is true, the `delegates` network will always be applied, along with those specified in the annotations.
+
+For example, a valid configuration using the `always_use_default` may look like:
+
+```
+{
+  "name": "multus-cni-network",
+  "type": "multus",
+  "delegates": [{"type": "flannel", "isDefaultGateway": true, "masterplugin": true}],
+  "always_use_default": true,
+  "kubeconfig": "/etc/kubernetes/kubelet.conf"
+}
+```
+
 ## Testing the Multus CNI ##
 ### Multiple Flannel Network
 Github user [YYGCui](https://github.com/YYGCui) has used Multiple flannel network to work with Multus CNI plugin. Please refer this [closed issue](https://github.com/Intel-Corp/multus-cni/issues/7) for Multiple overlay network support with Multus CNI.


### PR DESCRIPTION
Forces adding the default network(s) (e.g. anything that's specified in the `delegates` field) when the user specifies a new field in the configuration file, `always_use_default`.

When `always_use_default` is set, we append the network configuration items found as CRD objects as interfaces along with what was found in the default, and we set "masterplugin" only for the default network. 

Additionally, when `always_use_default` is set, it's required that you're using CRDs, so an error message is added when you have set `always_use_default` but have not set either the `kubeconfig` option or the `delegates` field.

Addresses #2 