### PR TITLE
Add 'go fmt', golint and 'go vet' in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,14 @@ dist: trusty
 before_install:
   - sudo apt-get update -qq
 
-#install:
-#  - go get .
-#  - go get github.com/golang/lint/golint
+install:
+  - go get github.com/golang/lint/golint
 
-#before_script:
-#  - go vet .
-#  - golint . | xargs -r false
+before_script:
+  - golint ./multus/... | grep -v ALL_CAPS | xargs -r false
+  - go fmt ./multus/...
+  - go vet ./multus/...
+#  - gocyclo -over 15 ./multus
 
 script:
   - ./build

--- a/multus/multus.go
+++ b/multus/multus.go
@@ -43,15 +43,12 @@ const defaultCNIDir = "/var/lib/cni/multus"
 var masterpluginEnabled bool
 var defaultcninetwork bool
 
+// NetConf for cni config file written in json
 type NetConf struct {
 	types.NetConf
 	CNIDir     string                   `json:"cniDir"`
 	Delegates  []map[string]interface{} `json:"delegates"`
 	Kubeconfig string                   `json:"kubeconfig"`
-}
-
-type PodNet struct {
-	Networkname string `json:"name"`
 }
 
 type netplugin struct {
@@ -316,7 +313,7 @@ func parsePodNetworkObject(podnetwork string) ([]map[string]interface{}, error) 
 			if len(atItems) == 2 {
 				m["interfaceRequest"] = atItems[1]
 			}
-			podNet = append(podNet,m)
+			podNet = append(podNet, m)
 		}
 	}
 
@@ -324,8 +321,8 @@ func parsePodNetworkObject(podnetwork string) ([]map[string]interface{}, error) 
 }
 
 func isJSON(str string) bool {
-    var js json.RawMessage
-    return json.Unmarshal([]byte(str), &js) == nil
+	var js json.RawMessage
+	return json.Unmarshal([]byte(str), &js) == nil
 }
 
 func getpluginargs(name string, args string, primary bool, ifname string) (string, error) {
@@ -345,7 +342,7 @@ func getpluginargs(name string, args string, primary bool, ifname string) (strin
 	if ifname != "" {
 		tmpargs = append(tmpargs, fmt.Sprintf(`"ifnameRequest": "%s",`, ifname))
 	}
-	tmpargs = append(tmpargs, args[strings.Index(args, "\"") : len(args)-1])
+	tmpargs = append(tmpargs, args[strings.Index(args, "\""):len(args)-1])
 
 	var str bytes.Buffer
 
@@ -439,8 +436,10 @@ func getMultusDelegates(delegate string) ([]map[string]interface{}, error) {
 	return tmpNetconf.Delegates, nil
 }
 
+// NoK8sNetworkError indicates error, no network in kubernetes
 type NoK8sNetworkError string
-func (e NoK8sNetworkError) Error() string  { return string(e) }
+
+func (e NoK8sNetworkError) Error() string { return string(e) }
 
 func getK8sNetwork(args *skel.CmdArgs, kubeconfig string) ([]map[string]interface{}, error) {
 	k8sArgs := K8sArgs{}


### PR DESCRIPTION
This change introduces go fmt/golint/go vet in CI pipeline to check
the code for each commit. In addition, this change changes code
to pass these checks.

I skip to run gocyclo because current multus exceeds complexity > 15 (cmdAdd/cmdDel).

This PR address #12.